### PR TITLE
refactor: sort -> cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/gqlc/compiler"
 	"github.com/gqlc/gqlc/gen"
-	tsort "github.com/gqlc/gqlc/sort"
 	"github.com/gqlc/graphql/ast"
 	"github.com/gqlc/graphql/parser"
 	"github.com/gqlc/graphql/token"
@@ -17,7 +16,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -101,9 +99,7 @@ func root(fs afero.Fs, geners *[]*genFlag, iPaths []string, args ...string) (err
 	// Convert types from IR to []*ast.TypeDecl
 	docs = docs[:0]
 	for doc, types := range docsIR {
-		dtypes := tsort.TypeSlice(compiler.FromIR(types))
-		sort.Sort(dtypes)
-		doc.Types = dtypes
+		doc.Types = sortTypeDecls(compiler.FromIR(types))
 
 		docs = append(docs, doc)
 	}

--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -1,31 +1,41 @@
-// Package sort provides sorting utilities for sorting type declarations.
-package sort
+// sort.go sorts type decls by type and name
+
+package cmd
 
 import (
 	"github.com/gqlc/graphql/ast"
+	"sort"
 )
 
-// DeclType defines the order of types in the .md file
-type DeclType uint16
+// sortTypeDecls sorts type declarations both lexigraphically and by type.
+func sortTypeDecls(decls []*ast.TypeDecl) []*ast.TypeDecl {
+	dtypes := typeSlice(decls)
+	sort.Sort(dtypes)
+
+	return dtypes
+}
+
+// declType defines the order of types in the .md file
+type declType uint16
 
 // Top-Level type declarations in GraphQL IDL.
 const (
-	SchemaType DeclType = 1 << iota
-	ScalarType
-	ObjectType
-	InterType
-	UnionType
-	EnumType
-	InputType
-	DirectiveType
-	ExtendType
+	schemaType declType = 1 << iota
+	scalarType
+	objectType
+	interType
+	unionType
+	enumType
+	inputType
+	directiveType
+	extendType
 )
 
-// TypeSlice represents a list of GraphQL type declarations
-type TypeSlice []*ast.TypeDecl
+// typeSlice represents a list of GraphQL type declarations
+type typeSlice []*ast.TypeDecl
 
-func (s TypeSlice) Len() int { return len(s) }
-func (s TypeSlice) Less(i, j int) bool {
+func (s typeSlice) Len() int { return len(s) }
+func (s typeSlice) Less(i, j int) bool {
 	it, jt := s[i], s[j]
 
 	var its, jts *ast.TypeSpec
@@ -43,42 +53,42 @@ func (s TypeSlice) Less(i, j int) bool {
 	}
 
 	// Schema < Scalar < Object < Interface < Union < Enum < Input < Directive
-	var iType, jType DeclType
+	var iType, jType declType
 	switch its.Type.(type) {
 	case *ast.TypeSpec_Schema:
-		iType = SchemaType
+		iType = schemaType
 	case *ast.TypeSpec_Scalar:
-		iType = ScalarType
+		iType = scalarType
 	case *ast.TypeSpec_Object:
-		iType = ObjectType
+		iType = objectType
 	case *ast.TypeSpec_Interface:
-		iType = InterType
+		iType = interType
 	case *ast.TypeSpec_Union:
-		iType = UnionType
+		iType = unionType
 	case *ast.TypeSpec_Enum:
-		iType = EnumType
+		iType = enumType
 	case *ast.TypeSpec_Input:
-		iType = InputType
+		iType = inputType
 	case *ast.TypeSpec_Directive:
-		iType = DirectiveType
+		iType = directiveType
 	}
 	switch jts.Type.(type) {
 	case *ast.TypeSpec_Schema:
-		jType = SchemaType
+		jType = schemaType
 	case *ast.TypeSpec_Scalar:
-		jType = ScalarType
+		jType = scalarType
 	case *ast.TypeSpec_Object:
-		jType = ObjectType
+		jType = objectType
 	case *ast.TypeSpec_Interface:
-		jType = InterType
+		jType = interType
 	case *ast.TypeSpec_Union:
-		jType = UnionType
+		jType = unionType
 	case *ast.TypeSpec_Enum:
-		jType = EnumType
+		jType = enumType
 	case *ast.TypeSpec_Input:
-		jType = InputType
+		jType = inputType
 	case *ast.TypeSpec_Directive:
-		jType = DirectiveType
+		jType = directiveType
 	}
 
 	if iType != jType {
@@ -87,4 +97,4 @@ func (s TypeSlice) Less(i, j int) bool {
 
 	return its.Name.Name < jts.Name.Name
 }
-func (s TypeSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s typeSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/cmd/sort_test.go
+++ b/cmd/sort_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"bytes"
+	"github.com/golang/protobuf/proto"
+	"github.com/gqlc/graphql/ast"
+	"testing"
+)
+
+func TestSortTypeDecls(t *testing.T) {
+	testCases := []struct {
+		name   string
+		types  []*ast.TypeSpec
+		sorted []*ast.TypeSpec
+	}{
+		{
+			name: "ByName",
+			types: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+			},
+			sorted: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+			},
+		},
+		{
+			name: "ByType",
+			types: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Schema{
+						Schema: &ast.SchemaType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Enum{
+						Enum: &ast.EnumType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Object{
+						Object: &ast.ObjectType{},
+					},
+				},
+			},
+			sorted: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Schema{
+						Schema: &ast.SchemaType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Object{
+						Object: &ast.ObjectType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Enum{
+						Enum: &ast.EnumType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+			},
+		},
+		{
+			name: "ByBoth",
+			types: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+			},
+			sorted: []*ast.TypeSpec{
+				{
+					Name: &ast.Ident{Name: "a"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "q"},
+					Type: &ast.TypeSpec_Scalar{
+						Scalar: &ast.ScalarType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "n"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+				{
+					Name: &ast.Ident{Name: "z"},
+					Type: &ast.TypeSpec_Directive{
+						Directive: &ast.DirectiveType{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subT *testing.T) {
+			types := make([]*ast.TypeDecl, 0, len(testCase.types))
+			for _, spec := range testCase.types {
+				types = append(types, &ast.TypeDecl{Spec: &ast.TypeDecl_TypeSpec{TypeSpec: spec}})
+			}
+
+			stypes := sortTypeDecls(types)
+
+			for i, st := range stypes {
+				cmpSpec := st.Spec.(*ast.TypeDecl_TypeSpec).TypeSpec
+
+				ogb, err := proto.Marshal(testCase.sorted[i])
+				if err != nil {
+					subT.Error(err)
+					return
+				}
+
+				cb, err := proto.Marshal(cmpSpec)
+				if err != nil {
+					subT.Error(err)
+					return
+				}
+
+				if !bytes.Equal(cb, ogb) {
+					subT.Fail()
+				}
+			}
+		})
+	}
+}

--- a/doc/doc_test.go
+++ b/doc/doc_test.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/gqlc/gqlc/gen"
-	"github.com/gqlc/gqlc/sort"
 	"github.com/gqlc/graphql/ast"
 	"github.com/gqlc/graphql/parser"
 	"github.com/gqlc/graphql/token"
@@ -120,13 +119,13 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestAddContent(t *testing.T) {
-	mask := sort.SchemaType | sort.ScalarType | sort.ObjectType | sort.InterType | sort.UnionType | sort.EnumType | sort.InputType | sort.DirectiveType | sort.ExtendType
+	mask := schemaType | scalarType | objectType | interType | unionType | enumType | inputType | directiveType | extendType
 
 	testCases := []struct {
 		Name string
 		C    []struct {
 			name string
-			typ  sort.DeclType
+			typ  declType
 		}
 		Total int
 	}{
@@ -134,11 +133,11 @@ func TestAddContent(t *testing.T) {
 			Name: "SingleType",
 			C: []struct {
 				name string
-				typ  sort.DeclType
+				typ  declType
 			}{
 				{
 					name: "Test",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 			},
 			Total: 2,
@@ -147,19 +146,19 @@ func TestAddContent(t *testing.T) {
 			Name: "MultiSameType",
 			C: []struct {
 				name string
-				typ  sort.DeclType
+				typ  declType
 			}{
 				{
 					name: "A",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 				{
 					name: "B",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 				{
 					name: "C",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 			},
 			Total: 4,
@@ -168,31 +167,31 @@ func TestAddContent(t *testing.T) {
 			Name: "ManyTypes",
 			C: []struct {
 				name string
-				typ  sort.DeclType
+				typ  declType
 			}{
 				{
 					name: "A",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 				{
 					name: "B",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 				{
 					name: "C",
-					typ:  sort.ScalarType,
+					typ:  scalarType,
 				},
 				{
 					name: "A",
-					typ:  sort.ObjectType,
+					typ:  objectType,
 				},
 				{
 					name: "B",
-					typ:  sort.ObjectType,
+					typ:  objectType,
 				},
 				{
 					name: "C",
-					typ:  sort.ObjectType,
+					typ:  objectType,
 				},
 			},
 			Total: 8,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements** (remove any that don't apply)
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactors `sort` package into `cmd` due to type sorting strictly being a cli internal i.e. generators shouldn't rely on it or its internal types


* **What is the current behavior?** (You can also link to an open issue here)
The `sort` package exports "internal" types solely to be used in the `doc` generator