### PR TITLE
fix(gqlc/cmd): sub cmds and args are now differentiable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ argument given to this type of flag is the same format as the *_opt
 key=value pairs above.`,
 	Example:            "gqlc -I . --doc_out ./docs --go_out ./goservice --js_out ./jsservice api.gql",
 	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
 }
 
 func init() {


### PR DESCRIPTION
Closes #39 