### PR TITLE
refactor(cmd): improve flag handling

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -88,20 +88,7 @@ func NewCLI(opts ...option) (c *CommandLine) {
 func (c *CommandLine) AllowPlugins(prefix string) { *c.pluginPrefix = prefix }
 
 // RegisterGenerator registers a generator with the compiler.
-func (c *CommandLine) RegisterGenerator(g gen.Generator, details ...string) {
-	l := len(details)
-	var name, opt, help string
-	switch {
-	case l == 2:
-		name, help = details[0], details[1]
-	case l > 3:
-		fallthrough
-	case l == 3:
-		name, opt, help = details[0], details[1], details[2]
-	default:
-		panic("invalid generator flag details")
-	}
-
+func (c *CommandLine) RegisterGenerator(g gen.Generator, name, opt, help string) {
 	opts := make(map[string]interface{})
 
 	c.Flags().Var(&genFlag{

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -34,7 +34,8 @@ type CommandLine struct {
 	*cobra.Command
 
 	pluginPrefix *string
-	geners       []*genFlag
+	geners       []generator
+	outDirs      []string
 	fp           *fparser
 	fs           afero.Fs
 }
@@ -59,12 +60,12 @@ func NewCLI(opts ...option) (c *CommandLine) {
 	if c.Command != nil {
 		return
 	}
+
 	c.Command = rootCmd
 	c.PreRunE = chainPreRunEs(
-		parseFlags(c.pluginPrefix, &c.geners, c.fp),
 		validateArgs,
 		validatePluginTypes(c.fs),
-		initGenDirs(c.fs, c.geners),
+		initGenDirs(c.fs, &c.outDirs),
 	)
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(cmd.Flags().Args()) == 0 || cmd.Flags().Lookup("help").Changed {
@@ -76,7 +77,7 @@ func NewCLI(opts ...option) (c *CommandLine) {
 			return err
 		}
 
-		return root(c.fs, &c.geners, importPaths, cmd.Flags().Args()...)
+		return root(c.fs, c.geners, importPaths, cmd.Flags().Args()...)
 	}
 
 	return
@@ -91,16 +92,18 @@ func (c *CommandLine) AllowPlugins(prefix string) { *c.pluginPrefix = prefix }
 func (c *CommandLine) RegisterGenerator(g gen.Generator, name, opt, help string) {
 	opts := make(map[string]interface{})
 
-	c.Flags().Var(&genFlag{
-		Generator: g,
-		outDir:    new(string),
-		opts:      opts,
-		geners:    &c.geners,
-		fp:        c.fp,
-	}, name, help)
+	f := genFlag{
+		g:      g,
+		opts:   opts,
+		geners: &c.geners,
+		fp:     c.fp,
+	}
+
+	c.Flags().Var(f, name, help)
 
 	if opt != "" {
-		c.Flags().Var(&genOptFlag{opts: opts, fp: c.fp}, opt, "Pass additional options to generator.")
+		f.isOpt = true
+		c.Flags().Var(f, opt, "Pass additional options to generator.")
 	}
 }
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -75,9 +75,16 @@ func TestCli_RegisterGenerator(t *testing.T) {
 				return
 			}
 
-			f := testCli.Flags().Lookup(name).Value.(*genFlag)
-			if testCase.OutDir != *f.outDir {
-				subT.Logf("mismatched output dirs: %s:%s", *f.outDir, testCase.OutDir)
+			f := testCli.Flags().Lookup(name).Value.(genFlag)
+			matched := false
+			for _, g := range *f.geners {
+				if testCase.OutDir == g.outDir {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				subT.Logf("unmatched output dir for: %s", testCase.OutDir)
 				subT.Fail()
 				return
 			}

--- a/cmd/flag_test.go
+++ b/cmd/flag_test.go
@@ -66,8 +66,7 @@ func TestGenOptFlag(t *testing.T) {
 		t.Run(testCase.Name, func(subT *testing.T) {
 			f := &genFlag{
 				opts:   make(map[string]interface{}),
-				outDir: new(string),
-				geners: new([]*genFlag),
+				geners: new([]generator),
 				fp:     &fparser{Scanner: new(scanner.Scanner)},
 			}
 
@@ -137,8 +136,7 @@ func TestGenOutFlag(t *testing.T) {
 		t.Run(testCase.Name, func(subT *testing.T) {
 			f := &genFlag{
 				opts:   make(map[string]interface{}),
-				outDir: new(string),
-				geners: new([]*genFlag),
+				geners: new([]generator),
 				fp:     &fparser{Scanner: new(scanner.Scanner)},
 			}
 
@@ -159,8 +157,9 @@ func TestGenOutFlag(t *testing.T) {
 				return
 			}
 
-			if testCase.OutDir != *f.outDir {
-				subT.Logf("mismatched outdirs: %s:%s", testCase.OutDir, *f.outDir)
+			ex := (*f.geners)[0].outDir
+			if testCase.OutDir != ex {
+				subT.Logf("mismatched outdirs: %s:%s", testCase.OutDir, ex)
 				subT.Fail()
 				return
 			}

--- a/cmd/pre_test.go
+++ b/cmd/pre_test.go
@@ -11,7 +11,7 @@ import (
 func TestParseFlags(t *testing.T) {
 	testCli := NewCLI()
 	testGen := newMockGenerator(t)
-	testCli.RegisterGenerator(testGen, "a_out", "A test generator.")
+	testCli.RegisterGenerator(testGen, "a_out", "", "A test generator.")
 	testCli.RegisterGenerator(testGen, "b_out", "b_opt", "A second test generator")
 
 	testCases := []struct {

--- a/cmd/pre_test.go
+++ b/cmd/pre_test.go
@@ -97,12 +97,9 @@ var (
 
 func TestInitGenDirs(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	gens := []*genFlag{
-		{outDir: &aDir},
-		{outDir: &bDir},
-	}
+	gens := []string{aDir, bDir}
 
-	err := initGenDirs(fs, gens)(nil, nil)
+	err := initGenDirs(fs, &gens)(nil, nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -206,12 +206,11 @@ func TestRoot(t *testing.T) {
 			g := newMockGenerator(subT)
 			testCase.expect(g)
 
-			geners := []*genFlag{{
+			geners := []generator{{
 				Generator: g,
-				outDir:    new(string),
 			}}
 
-			err := root(testFs, &geners, testCase.IPaths, testCase.Args...)
+			err := root(testFs, geners, testCase.IPaths, testCase.Args...)
 			if err != nil {
 				subT.Error(err)
 				return


### PR DESCRIPTION
The goal is to no longer have flag parsing disabled in cobra.